### PR TITLE
FoodEater: Don't eat while bank is open

### DIFF
--- a/foodeater/foodeater.gradle.kts
+++ b/foodeater/foodeater.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.6.0"
+version = "0.7.0"
 
 project.extra["PluginName"] = "Food Eater"
 project.extra["PluginDescription"] = "Automatically eats food"

--- a/foodeater/src/main/java/net/runelite/client/plugins/foodeater/FoodEaterPlugin.java
+++ b/foodeater/src/main/java/net/runelite/client/plugins/foodeater/FoodEaterPlugin.java
@@ -84,6 +84,11 @@ public class FoodEaterPlugin extends Plugin
 				return;
 			}
 
+			if (client.getItemContainer(InventoryID.BANK) != null)
+			{
+				return;
+			}
+
 			for (WidgetItem item : inventory.getWidgetItems())
 			{
 				final String name = this.itemManager.getItemDefinition(item.getId()).getName();


### PR DESCRIPTION
When the bank is open, FoodEater will not eat if you're HP is below the threshold until the bank is closed